### PR TITLE
Rename parameters and add discard pattern vars

### DIFF
--- a/project/demos/AvoidCollisions/Avoider.gd
+++ b/project/demos/AvoidCollisions/Avoider.gd
@@ -40,7 +40,7 @@ func setup(
 			proximity_radius: float,
 			boundary_right: float,
 			boundary_bottom: float,
-			draw_proximity: bool,
+			_draw_proximity: bool,
 			rng: RandomNumberGenerator
 	) -> void:
 	rng.randomize()
@@ -58,7 +58,7 @@ func setup(
 	
 	agent.linear_drag_percentage = _drag
 	
-	self.draw_proximity = draw_proximity
+	draw_proximity = _draw_proximity
 	
 	priority.add(avoid)
 	priority.add(seek)

--- a/project/demos/AvoidCollisions/Spawner.gd
+++ b/project/demos/AvoidCollisions/Spawner.gd
@@ -37,7 +37,7 @@ func _ready() -> void:
 		child.set_proximity_agents(avoider_agents)
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	for child in get_children():
 		child.global_position = child.global_position.posmodv(boundaries)
 

--- a/project/demos/DemoPickerUI.gd
+++ b/project/demos/DemoPickerUI.gd
@@ -11,9 +11,9 @@ onready var button: Button = $VBoxContainer/Button
 
 
 func _ready() -> void:
-	list.connect("demo_selected", self, "set_demo_path")
-	list.connect("item_activated", self, "emit_signal", ["demo_requested"])
-	button.connect("pressed", self, "emit_signal", ["demo_requested"])
+	var _err := list.connect("demo_selected", self, "set_demo_path")
+	_err = list.connect("item_activated", self, "emit_signal", ["demo_requested"])
+	_err = button.connect("pressed", self, "emit_signal", ["demo_requested"])
 	demo_path = list.file_paths[0]
 
 

--- a/project/demos/Demos.gd
+++ b/project/demos/Demos.gd
@@ -7,8 +7,8 @@ onready var button_go_back: Button = $ButtonGoBack
 
 
 func _ready() -> void:
-	demo_picker.connect("demo_requested", self, "_on_DemoPickerUI_demo_requested")
-	button_go_back.connect("pressed", self, "_on_ButtonGoBack_pressed")
+	var _err := demo_picker.connect("demo_requested", self, "_on_DemoPickerUI_demo_requested")
+	_err = button_go_back.connect("pressed", self, "_on_ButtonGoBack_pressed")
 
 
 func _on_DemoPickerUI_demo_requested() -> void:

--- a/project/demos/Face/FaceDemo.gd
+++ b/project/demos/Face/FaceDemo.gd
@@ -8,7 +8,6 @@ export(int, 0, 359, 2) var deceleration_radius := 45 setget set_deceleration_rad
 export(float, 0, 1000, 40) var player_speed := 600.0 setget set_player_speed
 
 onready var player := $Player
-onready var gui := $GUI
 onready var turret := $Turret
 
 

--- a/project/demos/Face/Player.gd
+++ b/project/demos/Face/Player.gd
@@ -6,9 +6,9 @@ var speed: float
 onready var agent := GSTAgentLocation.new()
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	var movement := _get_movement()
-	move_and_slide(movement * speed)
+	var _velocity := move_and_slide(movement * speed)
 	agent.position = Vector3(global_position.x, global_position.y, 0)
 
 

--- a/project/demos/PopulateItemList.gd
+++ b/project/demos/PopulateItemList.gd
@@ -7,7 +7,7 @@ var file_paths := PoolStringArray()
 
 
 func _ready() -> void:
-	self.connect("item_selected", self, "_on_item_selected")
+	var _err := self.connect("item_selected", self, "_on_item_selected")
 
 	var this_directory: String = get_tree().current_scene.filename.rsplit("/", false, 1)[0]
 	file_paths = _find_files(this_directory, ["*Demo.tscn"], true)
@@ -25,7 +25,7 @@ func populate(demos: PoolStringArray) -> void:
 
 func sentencify(line: String) -> String:
 	var regex := RegEx.new()
-	regex.compile("[A-Z]")
+	var _err := regex.compile("[A-Z]")
 	
 	line = line.split(".", true, 1)[0]
 	line = regex.sub(line, " $0", true)
@@ -33,31 +33,31 @@ func sentencify(line: String) -> String:
 
 
 func _find_files(dirpath := "", patterns := PoolStringArray(), is_recursive := false, do_skip_hidden := true) -> PoolStringArray:
-	var file_paths: = PoolStringArray()
+	var _file_paths: = PoolStringArray()
 	var directory: = Directory.new()
 
 	if not directory.dir_exists(dirpath):
 		printerr("The directory does not exist: %s" % dirpath)
-		return file_paths
+		return _file_paths
 	if not directory.open(dirpath) == OK:
 		printerr("Could not open the following dirpath: %s" % dirpath)
-		return file_paths
+		return _file_paths
 
-	directory.list_dir_begin(true, do_skip_hidden)
+	var _err := directory.list_dir_begin(true, do_skip_hidden)
 	var file_name: = directory.get_next()
-	var subdirectories: = PoolStringArray()
+
 	while file_name != "":
 		if directory.current_is_dir() and is_recursive:
 			var subdirectory: = dirpath.plus_file(file_name)
-			file_paths.append_array(_find_files(subdirectory, patterns, is_recursive))
+			_file_paths.append_array(_find_files(subdirectory, patterns, is_recursive))
 		else:
 			for pattern in patterns:
 				if file_name.match(pattern):
-					file_paths.append(dirpath.plus_file(file_name))
+					_file_paths.append(dirpath.plus_file(file_name))
 		file_name = directory.get_next()
 
 	directory.list_dir_end()
-	return file_paths
+	return _file_paths
 
 
 func _on_item_selected(index: int) -> void:

--- a/project/demos/PursueSeek/BoundaryManager.gd
+++ b/project/demos/PursueSeek/BoundaryManager.gd
@@ -12,6 +12,6 @@ func _ready() -> void:
 	)
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	for ship in get_children():
 		ship.position = ship.position.posmodv(_world_bounds)

--- a/project/demos/PursueSeek/Player.gd
+++ b/project/demos/PursueSeek/Player.gd
@@ -44,15 +44,15 @@ func _physics_process(delta: float) -> void:
 func _calculate_angular_velocity(
 	horizontal_movement: float,
 	current_velocity: float,
-	thruster_strength: float,
-	velocity_max: float,
+	_thruster_strength: float,
+	_velocity_max: float,
 	ship_drag: float,
 	delta: float
 ) -> float:
 	var velocity := clamp(
-		current_velocity + thruster_strength * horizontal_movement * delta,
-		-velocity_max,
-		velocity_max
+		current_velocity + _thruster_strength * horizontal_movement * delta,
+		-_velocity_max,
+		_velocity_max
 	)
 	
 	velocity = lerp(velocity, 0, ship_drag)

--- a/project/demos/Quickstart/Bullet.gd
+++ b/project/demos/Quickstart/Bullet.gd
@@ -10,7 +10,7 @@ onready var timer := $Lifetime
 
 
 func _ready() -> void:
-	timer.connect("timeout", self, "_on_Lifetime_timeout")
+	var _err := timer.connect("timeout", self, "_on_Lifetime_timeout")
 	timer.start()
 
 

--- a/project/demos/SeekFlee/Boundaries.gd
+++ b/project/demos/SeekFlee/Boundaries.gd
@@ -5,7 +5,7 @@ const COLOR := Color("8fde5d")
 
 
 func _ready() -> void:
-	get_tree().root.connect("size_changed", self, "_on_SceneTree_size_changed")
+	var _err := get_tree().root.connect("size_changed", self, "_on_SceneTree_size_changed")
 
 
 func _draw() -> void:

--- a/project/demos/SeekFlee/Player.gd
+++ b/project/demos/SeekFlee/Player.gd
@@ -10,12 +10,12 @@ func _ready() -> void:
 	agent.position = GSTUtils.to_vector3(global_position)
 
 
-func _physics_process(delta: float) -> void:
+func _physics_process(_delta: float) -> void:
 	var movement := _get_movement()
 	if movement.length_squared() < 0.01:
 		return
 	
-	move_and_slide(movement * speed)
+	var _velocity := move_and_slide(movement * speed)
 	agent.position = GSTUtils.to_vector3(global_position)
 
 

--- a/project/demos/SeekFlee/SeekFleeDemo.gd
+++ b/project/demos/SeekFlee/SeekFleeDemo.gd
@@ -29,7 +29,7 @@ func _ready() -> void:
 	
 	player.speed = player_speed
 	
-	for i in range(spawner.entity_count):
+	for _i in range(spawner.entity_count):
 		var new_pos := Vector2(
 				rng.randf_range(0, camera_boundaries.size.x),
 				rng.randf_range(0, camera_boundaries.size.y)

--- a/project/project.godot
+++ b/project/project.godot
@@ -9,7 +9,7 @@
 config_version=4
 
 _global_script_classes=[ {
-"base": "CenterContainer",
+"base": "Control",
 "class": "DemoPickerUI",
 "language": "GDScript",
 "path": "res://demos/DemoPickerUI.gd"

--- a/project/src/Agents/GSTKinematicBody2DAgent.gd
+++ b/project/src/Agents/GSTKinematicBody2DAgent.gd
@@ -19,14 +19,14 @@ var movement_type: int
 var _last_position: Vector2
 
 
-func _init(body: KinematicBody2D, movement_type: int = MovementType.SLIDE) -> void:
-	if not body.is_inside_tree():
-		yield(body, "ready")
+func _init(_body: KinematicBody2D, _movement_type: int = MovementType.SLIDE) -> void:
+	if not _body.is_inside_tree():
+		yield(_body, "ready")
 	
-	self.body = body
-	self.movement_type = movement_type
+	body = _body
+	movement_type = _movement_type
 	
-	body.get_tree().connect("physics_frame", self, "_on_SceneTree_physics_frame")
+	var _err := body.get_tree().connect("physics_frame", self, "_on_SceneTree_physics_frame")
 
 
 # Moves the agent's `body` by target `acceleration`.
@@ -60,7 +60,7 @@ func _apply_collide_steering(accel: Vector3, delta: float) -> void:
 				Vector3.ZERO,
 				linear_drag_percentage
 		)
-	body.move_and_collide(GSTUtils.to_vector2(velocity) * delta)
+	var _collide := body.move_and_collide(GSTUtils.to_vector2(velocity) * delta)
 	if calculate_velocities:
 		linear_velocity = velocity
 
@@ -97,6 +97,8 @@ func _set_body(value: KinematicBody2D) -> void:
 
 
 func _on_SceneTree_physics_frame() -> void:
+	if not body.is_inside_tree():
+		return
 	var current_position: Vector2 = body.global_position
 	var current_orientation: float = body.rotation
 	

--- a/project/src/Agents/GSTSpecializedAgent.gd
+++ b/project/src/Agents/GSTSpecializedAgent.gd
@@ -36,5 +36,5 @@ var _applied_steering := false
 
 # Moves the agent's body by target `acceleration`.
 # tags: virtual
-func _apply_steering(acceleration: GSTTargetAcceleration, delta: float) -> void:
+func _apply_steering(_acceleration: GSTTargetAcceleration, _delta: float) -> void:
 	pass

--- a/project/src/Behaviors/GSTArrive.gd
+++ b/project/src/Behaviors/GSTArrive.gd
@@ -15,8 +15,8 @@ var deceleration_radius: float
 var time_to_reach := 0.1
 
 
-func _init(agent: GSTSteeringAgent, target: GSTAgentLocation).(agent) -> void:
-	self.target = target
+func _init(agent: GSTSteeringAgent, _target: GSTAgentLocation).(agent) -> void:
+	target = _target
 
 
 func _arrive(acceleration: GSTTargetAcceleration, target_position: Vector3) -> void:

--- a/project/src/Behaviors/GSTFollowPath.gd
+++ b/project/src/Behaviors/GSTFollowPath.gd
@@ -17,12 +17,12 @@ var prediction_time := 0.0
 
 func _init(
 		agent: GSTSteeringAgent,
-		path: GSTPath,
-		path_offset := 0.0,
-		prediction_time := 0.0).(agent, null) -> void:
-	self.path = path
-	self.path_offset = path_offset
-	self.prediction_time = prediction_time
+		_path: GSTPath,
+		_path_offset := 0.0,
+		_prediction_time := 0.0).(agent, null) -> void:
+	path = _path
+	path_offset = _path_offset
+	prediction_time = _prediction_time
 
 
 func _calculate_steering(acceleration: GSTTargetAcceleration) -> void:

--- a/project/src/Behaviors/GSTMatchOrientation.gd
+++ b/project/src/Behaviors/GSTMatchOrientation.gd
@@ -16,8 +16,8 @@ var deceleration_radius: float
 var time_to_reach: float = 0.1
 
 
-func _init(agent: GSTSteeringAgent, target: GSTAgentLocation).(agent) -> void:
-	self.target = target
+func _init(agent: GSTSteeringAgent, _target: GSTAgentLocation).(agent) -> void:
+	target = _target
 
 
 func _match_orientation(acceleration: GSTTargetAcceleration, desired_orientation: float) -> void:

--- a/project/src/Behaviors/GSTPriority.gd
+++ b/project/src/Behaviors/GSTPriority.gd
@@ -13,8 +13,8 @@ var last_selected_index: int
 var zero_threshold: float
 
 
-func _init(agent: GSTSteeringAgent, zero_threshold := 0.001).(agent) -> void:
-	self.zero_threshold = zero_threshold
+func _init(agent: GSTSteeringAgent, _zero_threshold := 0.001).(agent) -> void:
+	zero_threshold = _zero_threshold
 
 
 # Appends a steering behavior as a child of this container.

--- a/project/src/Behaviors/GSTPursue.gd
+++ b/project/src/Behaviors/GSTPursue.gd
@@ -13,10 +13,10 @@ var predict_time_max: float
 
 func _init(
 		agent: GSTSteeringAgent,
-		target: GSTSteeringAgent,
-		predict_time_max := 1.0).(agent) -> void:
-	self.target = target
-	self.predict_time_max = predict_time_max
+		_target: GSTSteeringAgent,
+		_predict_time_max := 1.0).(agent) -> void:
+	target = _target
+	predict_time_max = _predict_time_max
 
 
 func _calculate_steering(acceleration: GSTTargetAcceleration) -> void:

--- a/project/src/Behaviors/GSTSeek.gd
+++ b/project/src/Behaviors/GSTSeek.gd
@@ -8,8 +8,8 @@ extends GSTSteeringBehavior
 var target: GSTAgentLocation
 
 
-func _init(agent: GSTSteeringAgent, target: GSTAgentLocation).(agent) -> void:
-	self.target = target
+func _init(agent: GSTSteeringAgent, _target: GSTAgentLocation).(agent) -> void:
+	target = _target
 
 
 func _calculate_steering(acceleration: GSTTargetAcceleration) -> void:

--- a/project/src/Behaviors/GSTSeparation.gd
+++ b/project/src/Behaviors/GSTSeparation.gd
@@ -21,7 +21,7 @@ func _init(agent: GSTSteeringAgent, proximity: GSTProximity).(agent, proximity) 
 func _calculate_steering(acceleration: GSTTargetAcceleration) -> void:
 	acceleration.set_zero()
 	self._acceleration = acceleration
-	proximity._find_neighbors(_callback)
+	var _neighbors := proximity._find_neighbors(_callback)
 
 
 # Callback for the proximity to call when finding neighbors. Determines the amount of

--- a/project/src/GSTGroupBehavior.gd
+++ b/project/src/GSTGroupBehavior.gd
@@ -9,12 +9,12 @@ var proximity: GSTProximity
 var _callback := funcref(self, "_report_neighbor")
 
 
-func _init(agent: GSTSteeringAgent, proximity: GSTProximity).(agent) -> void:
-	self.proximity = proximity
+func _init(agent: GSTSteeringAgent, _proximity: GSTProximity).(agent) -> void:
+	proximity = _proximity
 
 
 # Internal callback for the behavior to define whether or not a member is
 # relevant
 # tags: virtual
-func _report_neighbor(neighbor: GSTSteeringAgent) -> bool:
+func _report_neighbor(_neighbor: GSTSteeringAgent) -> bool:
 	return false

--- a/project/src/GSTPath.gd
+++ b/project/src/GSTPath.gd
@@ -15,8 +15,8 @@ var _nearest_point_on_segment: Vector3
 var _nearest_point_on_path: Vector3
 
 
-func _init(waypoints: Array, is_open := false) -> void:
-	self.is_open = is_open
+func _init(waypoints: Array, _is_open := false) -> void:
+	is_open = _is_open
 	create_path(waypoints)
 	_nearest_point_on_segment = waypoints[0]
 	_nearest_point_on_path = waypoints[0]
@@ -128,7 +128,7 @@ class GSTSegment:
 	var cumulative_length: float
 
 
-	func _init(begin: Vector3, end: Vector3) -> void:
-		self.begin = begin
-		self.end = end
+	func _init(_begin: Vector3, _end: Vector3) -> void:
+		begin = _begin
+		end = _end
 		length = begin.distance_to(end)

--- a/project/src/GSTSteeringBehavior.gd
+++ b/project/src/GSTSteeringBehavior.gd
@@ -14,8 +14,8 @@ var is_enabled := true
 var agent: GSTSteeringAgent
 
 
-func _init(agent: GSTSteeringAgent) -> void:
-	self.agent = agent
+func _init(_agent: GSTSteeringAgent) -> void:
+	agent = _agent
 
 
 # Sets the `acceleration` with the behavior's desired amount of acceleration.

--- a/project/src/Proximities/GSTProximity.gd
+++ b/project/src/Proximities/GSTProximity.gd
@@ -9,9 +9,9 @@ var agent: GSTSteeringAgent
 var agents := []
 
 
-func _init(agent: GSTSteeringAgent, agents: Array) -> void:
-	self.agent = agent
-	self.agents = agents
+func _init(_agent: GSTSteeringAgent, _agents: Array) -> void:
+	agent = _agent
+	agents = _agents
 
 
 # Returns a number of neighbors based on a `callback` function.
@@ -19,5 +19,5 @@ func _init(agent: GSTSteeringAgent, agents: Array) -> void:
 # `_find_neighbors` calls `callback` for each agent in the `agents` array and
 # adds one to the count if its `callback` returns true.
 # tags: virtual
-func _find_neighbors(callback: FuncRef) -> int:
+func _find_neighbors(_callback: FuncRef) -> int:
 	return 0

--- a/project/src/Proximities/GSTRadiusProximity.gd
+++ b/project/src/Proximities/GSTRadiusProximity.gd
@@ -11,8 +11,8 @@ var _last_frame := 0
 var _scene_tree: SceneTree
 
 
-func _init(agent: GSTSteeringAgent, agents: Array, radius: float).(agent, agents) -> void:
-	self.radius = radius
+func _init(agent: GSTSteeringAgent, agents: Array, _radius: float).(agent, agents) -> void:
+	radius = _radius
 	_scene_tree = Engine.get_main_loop()
 
 


### PR DESCRIPTION
The framework currently produces a lot of warnings regarding shadowed variables and unused return values. Individually, it's only 0-3, but if you start to have quite a few of those behaviors floating around, they'll all start chiming in.

They're harmless because we accounted for them with use of `self` or just ignoring them, but in Harvester, for example, there's some 40 warnings and only a portion of them come from the game itself rather than the framework.

For unused return values, just the discard pattern is fine.

However, for shadowed variables, right now I added underscores to differentiate them, because I struggled to come up with meaningful names to replace them by. It's not that great a naming scheme, so I'd be looking for second opinions.