### PR TITLE
Fix global_position for KinematicBody3DAgent

### DIFF
--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody3DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody3DAgent.gd
@@ -94,7 +94,7 @@ func _apply_position_steering(accel: Vector3, delta: float) -> void:
 		velocity = velocity.linear_interpolate(
 			Vector3.ZERO, linear_drag_percentage
 		)
-	_body.global_position += velocity * delta
+	_body.global_transform.origin += velocity * delta
 	if calculate_velocities:
 		linear_velocity = velocity
 


### PR DESCRIPTION
there's no global_position for KinematicBody(3D).
use `global_transform.origin` instead.

**Please check if the PR fulfills these requirements:**

- [x] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**

It fixed an error when using `GSAIKinematicBody3DAgent` which is there's no property `global_position` for `KinematicBody`

**Does this PR introduce a breaking change?**

No

## New feature or change ##


**What is the current behavior?** 



**What is the new behavior?**



**Other information**
