### PR TITLE
stop agents from processing when they are outside of the scene tree

### DIFF
--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody2DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody2DAgent.gd
@@ -49,6 +49,9 @@ func _apply_sliding_steering(accel: Vector3, delta: float) -> void:
 	var _body: KinematicBody2D = _body_ref.get_ref()
 	if not _body:
 		return
+
+	if not _body.is_inside_tree():
+		return
 		
 	var velocity := GSAIUtils.to_vector2(linear_velocity + accel * delta).clamped(linear_speed_max)
 	if apply_linear_drag:

--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody3DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody3DAgent.gd
@@ -132,6 +132,9 @@ func _on_SceneTree_physics_frame() -> void:
 	if not _body:
 		return
 
+	if not _body.is_inside_tree():
+		return
+
 	var current_position := _body.transform.origin
 	var current_orientation := _body.rotation.y
 

--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIRigidBody2DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIRigidBody2DAgent.gd
@@ -50,6 +50,9 @@ func _on_SceneTree_frame() -> void:
 	var _body: RigidBody2D = _body_ref.get_ref()
 	if not _body:
 		return
+	
+	if not _body.is_inside_tree():
+		return
 
 	var current_position := _body.global_position
 	var current_orientation := _body.rotation

--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIRigidBody3DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIRigidBody3DAgent.gd
@@ -49,6 +49,9 @@ func _on_SceneTree_frame() -> void:
 	var _body: RigidBody = _body_ref.get_ref()
 	if not _body:
 		return
+	
+	if not _body.is_inside_tree():
+		return
 		
 	var current_position := _body.transform.origin
 	var current_orientation := _body.rotation.y


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog. (Not sure if this is the changelog or if that's something different, please advise.)


Related issue (if applicable): #54 

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Fixes https://github.com/GDQuest/godot-steering-ai-framework/issues/54


**Does this PR introduce a breaking change?**
No.


## New feature or change ##


**What is the current behavior?** 
GSAI Kinematic/Rigid agents continue processing when they are outside of the scene tree.


**What is the new behavior?**
GSAI Kinematic/Rigid agents cease processing if they are outside of the scene tree.



**Other information**
