### PR TITLE
stop agents from processing if the scene tree is paused

### DIFF
--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody2DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody2DAgent.gd
@@ -50,7 +50,7 @@ func _apply_sliding_steering(accel: Vector3, delta: float) -> void:
 	if not _body:
 		return
 
-	if not _body.is_inside_tree():
+	if not _body.is_inside_tree() or _body.get_tree().paused:
 		return
 		
 	var velocity := GSAIUtils.to_vector2(linear_velocity + accel * delta).clamped(linear_speed_max)

--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody3DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIKinematicBody3DAgent.gd
@@ -132,7 +132,7 @@ func _on_SceneTree_physics_frame() -> void:
 	if not _body:
 		return
 
-	if not _body.is_inside_tree():
+	if not _body.is_inside_tree() or _body.get_tree().paused:
 		return
 
 	var current_position := _body.transform.origin

--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIRigidBody2DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIRigidBody2DAgent.gd
@@ -51,7 +51,7 @@ func _on_SceneTree_frame() -> void:
 	if not _body:
 		return
 	
-	if not _body.is_inside_tree():
+	if not _body.is_inside_tree() or _body.get_tree().paused:
 		return
 
 	var current_position := _body.global_position

--- a/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIRigidBody3DAgent.gd
+++ b/godot/addons/com.gdquest.godot-steering-ai-framework/Agents/GSAIRigidBody3DAgent.gd
@@ -50,7 +50,7 @@ func _on_SceneTree_frame() -> void:
 	if not _body:
 		return
 	
-	if not _body.is_inside_tree():
+	if not _body.is_inside_tree() or _body.get_tree().paused:
 		return
 		
 	var current_position := _body.transform.origin


### PR DESCRIPTION
**Please check if the PR fulfills these requirements:**

- [ ] The commit message follows our guidelines.
- For bug fixes and features:
    - [x] You tested the changes.
    - [ ] You updated the docs or changelog.


Related issue (if applicable): #

<!-- You don't have to fill all the information below if it is all explained in the linked issue above. -->

**What kind of change does this PR introduce?**
Fixes #56 


**Does this PR introduce a breaking change?**
No.


## New feature or change ##


**What is the current behavior?** 
GSAIKinematicBody agents update while the scene tree is paused, resulting in zeroed out velocity when the scene tree is unpaused.


**What is the new behavior?**
Stops GSAIKinematicBody agents from updating when the scene tree is paused.


**Other information**
